### PR TITLE
Add example Android VPN ad blocker

### DIFF
--- a/AdBlockerApp/LICENSE
+++ b/AdBlockerApp/LICENSE
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/AdBlockerApp/README.md
+++ b/AdBlockerApp/README.md
@@ -1,0 +1,40 @@
+# AdBlockerApp
+
+This directory contains a very minimal example of how you might begin
+building an Android ad blocker using a local VPN service. The code is
+not a full solution but demonstrates the basic structure for starting a
+`VpnService` and intercepting traffic.
+
+## Building the APK
+
+1. Install [Android Studio](https://developer.android.com/studio) and
+   open this directory as a new project.
+2. Make sure Kotlin support is enabled (the example code uses Kotlin).
+3. Create a new **Empty Activity** module or reuse the provided code.
+4. Place `AdBlockVpnService.kt` under
+   `app/src/main/java/com/example/adblocker/`.
+5. Update your `AndroidManifest.xml` to declare the VPN service:
+
+```xml
+<service
+    android:name=".AdBlockVpnService"
+    android:permission="android.permission.BIND_VPN_SERVICE">
+    <intent-filter>
+        <action android:name="android.net.VpnService" />
+    </intent-filter>
+</service>
+```
+
+6. Build and run the project from Android Studio. The generated APK will
+   be located in `app/build/outputs/apk/`.
+
+## How it works
+
+The service establishes a local VPN and can intercept all outgoing
+network packets. By inspecting each packet, you can drop connections to
+known ad servers or filter traffic based on a host list. Populate the
+filtering logic in the `TODO` section of `AdBlockVpnService.kt`.
+
+This is only a starting point. A complete ad blocker would need a robust
+list of ad domains and logic to parse network packets, which can be
+significant work.

--- a/AdBlockerApp/app/src/main/java/com/example/adblocker/AdBlockVpnService.kt
+++ b/AdBlockerApp/app/src/main/java/com/example/adblocker/AdBlockVpnService.kt
@@ -1,0 +1,56 @@
+package com.example.adblocker
+
+import android.net.VpnService
+import android.net.VpnService.Builder
+import android.os.ParcelFileDescriptor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import java.io.FileInputStream
+import java.io.FileOutputStream
+
+/**
+ * Simple VPN-based ad blocker. This is a very basic example and does not
+ * implement a full ad blocking engine. It shows how to start a VPN service
+ * that could filter traffic using a predefined host list.
+ */
+class AdBlockVpnService : VpnService() {
+    private var vpnInterface: ParcelFileDescriptor? = null
+
+    override fun onStartCommand(intent: android.content.Intent?, flags: Int, startId: Int): Int {
+        setupVpn()
+        return START_STICKY
+    }
+
+    private fun setupVpn() {
+        val builder = Builder()
+        builder.addAddress("10.0.0.2", 32)
+        builder.addRoute("0.0.0.0", 0)
+        vpnInterface = builder.setSession("AdBlocker").establish()
+        vpnInterface?.let {
+            GlobalScope.launch(Dispatchers.IO) {
+                runVpnLoop(it)
+            }
+        }
+    }
+
+    private fun runVpnLoop(fd: ParcelFileDescriptor) {
+        val inputStream = FileInputStream(fd.fileDescriptor)
+        val outputStream = FileOutputStream(fd.fileDescriptor)
+        val buffer = ByteArray(32767)
+        while (true) {
+            val length = inputStream.read(buffer)
+            if (length > 0) {
+                // TODO: Inspect packets and drop connections to ad servers
+                outputStream.write(buffer, 0, length)
+            } else {
+                Thread.sleep(10)
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        vpnInterface?.close()
+        super.onDestroy()
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple `AdBlockVpnService` demonstrating a VPN-based ad blocker
- document building an APK using Android Studio
- include MIT license for the sample code

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a2b52094c8323972bfa3d5e5c3271